### PR TITLE
fix accept:application/csv headers becoming persistent.

### DIFF
--- a/src/pages/Payment.vue
+++ b/src/pages/Payment.vue
@@ -73,13 +73,16 @@ export default {
     },
     methods: {
         onDownloadVouchers(format) {
-            NetMgr.setAccept(format);
-            NetMgr.apiGet('/traders/' + Store.trader.id + '/vouchers', function(response) {
-                var link = document.createElement("a");
-                link.download = 'vouchers.csv';
-                link.href = 'data:'+response.headers['content-type']+',' + encodeURIComponent(response.data);
-                link.click();
-            });
+            // Direct access to the get function is unpleasent, but seems neccessary for applying a one of CFG change.
+            var cfg = { headers : { 'Accept' : format}};
+            NetMgr.axiosInstance.get('/traders/' + Store.trader.id + '/vouchers', cfg)
+                .then(function(response) {
+                    var link = document.createElement("a");
+                    link.download = 'vouchers.csv';
+                    link.href = 'data:' + response.headers['content-type'] + ',' + encodeURIComponent(response.data);
+                    link.click();
+                })
+                .catch(); //TODO : bad file request handling
         },
         onRequestPayment() {
             Store.pendRecVouchers(

--- a/src/pages/Payment.vue
+++ b/src/pages/Payment.vue
@@ -73,7 +73,7 @@ export default {
     },
     methods: {
         onDownloadVouchers(format) {
-            // Direct access to the get function is unpleasent, but seems neccessary for applying a one of CFG change.
+            // Direct access to the get function is unpleasant, but seems necessary for applying a one of CFG change.
             var cfg = { headers : { 'Accept' : format}};
             NetMgr.axiosInstance.get('/traders/' + Store.trader.id + '/vouchers', cfg)
                 .then(function(response) {


### PR DESCRIPTION
When you change the defaults, changing them back again is a pain. Axios has a single-request config mechanism, employed here.  