### PR TITLE
prevent default  wont fire if keypress is backspace

### DIFF
--- a/src/pages/Tap.vue
+++ b/src/pages/Tap.vue
@@ -162,7 +162,8 @@ export default {
             var rxNumber = /\d/;
             var char = this.getKeyCharCode(event);
             
-            if (event.keyCode != 8) {
+            //event.keycode 8 is backspace, dont want to prevent default
+            if (event.keyCode !== 8) {
                 if (char.match(rxNumber)) {
                     if (this.voucherCode.length < event.target.maxlength) {
                         this.voucherCode += char;

--- a/src/pages/Tap.vue
+++ b/src/pages/Tap.vue
@@ -161,15 +161,17 @@ export default {
         onKeypressVoucherBox : function(event) {
             var rxNumber = /\d/;
             var char = this.getKeyCharCode(event);
-
-            if (char.match(rxNumber)) {
-                if (this.voucherCode.length < event.target.maxlength) {
-                    this.voucherCode += char;
+            
+            if (event.keyCode != 8) {
+                if (char.match(rxNumber)) {
+                    if (this.voucherCode.length < event.target.maxlength) {
+                        this.voucherCode += char;
+                    }
+                    return;
                 }
-                return;
+                event.preventDefault();
+                return false;
             }
-            event.preventDefault();
-            return false;
         },
         getKeyCharCode : function(event) {
             // Try to cross platform catch the keycode


### PR DESCRIPTION
https://trello.com/c/j9EoVMY8/238-bug-in-firefox-cannot-use-backspace-key-in-the-number-part-of-the-voucher-input-box

🐖 