### PR TITLE
source map set to false

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -108,7 +108,7 @@ if (process.env.NODE_ENV === 'production') {
             }
         }),
         new webpack.optimize.UglifyJsPlugin({
-            sourceMap: true,
+            sourceMap: false,
             compress: {
                 warnings: false
             }


### PR DESCRIPTION
Seems to work fine! Screenshots attached to trello card https://trello.com/c/InIGkayp/302-optimise-build-size-dont-include-buildmapjs-in-production