### PR TITLE
1.0/336 endless spinner

### DIFF
--- a/src/pages/Scan.vue
+++ b/src/pages/Scan.vue
@@ -76,9 +76,9 @@ export default {
     },
     methods:  {
         onRecordVoucher: function(event) {
-            this.startSpinner();
             //TODO: some proper validation
             if (this.voucherCode !== null && this.voucherCode.length > 0) {
+                this.startSpinner();
                 Store.addVoucherCode(this.sponsorCode.toUpperCase()+this.voucherCode,
                     // Success function
                     function(response) {
@@ -87,11 +87,11 @@ export default {
                             response.data.invalid.length > 0
                         ) {
                             this.showFail();
-                            this.errorMessage = "[xXx]The voucher code you entered is not valid. Please try again.";
+                            this.errorMessage = "[xXx] Please enter a valid voucher code.";
                         } else if (
                             response.data.fail.length > 0
                         ) {
-                            this.errorMessage = "[xXx]The voucher code you entered has previously been submitted. Please try again.";
+                            this.errorMessage = "[xXx] That voucher may have been used already.";
                         } else {
                             this.showValidate();
                             this.errorMessage = "";
@@ -106,6 +106,9 @@ export default {
                 this.voucherCode = "";
                 this.sponsorCode = "";
                 this.$refs.sponsorBox.focus();
+            } else {
+              this.showFail();
+              this.errorMessage = "[xXx] Please enter a valid code.";
             }
         },
 

--- a/src/pages/Scan.vue
+++ b/src/pages/Scan.vue
@@ -91,6 +91,7 @@ export default {
                         } else if (
                             response.data.fail.length > 0
                         ) {
+                            this.showFail();
                             this.errorMessage = "[xXx] That voucher may have been used already.";
                         } else {
                             this.showValidate();
@@ -108,7 +109,7 @@ export default {
                 this.$refs.sponsorBox.focus();
             } else {
               this.showFail();
-              this.errorMessage = "[xXx] Please enter a valid code.";
+              this.errorMessage = "[xXx] Please enter a valid voucher code.";
             }
         },
 

--- a/src/pages/Tap.vue
+++ b/src/pages/Tap.vue
@@ -66,7 +66,6 @@ export default {
     },
     methods:  {
         onRecordVoucher: function(event) {
-
             //TODO: some proper validation
             if (this.voucherCode !== null && this.voucherCode.length > 0) {
                 this.startSpinner();

--- a/src/pages/Tap.vue
+++ b/src/pages/Tap.vue
@@ -82,7 +82,7 @@ export default {
                             response.data.fail.length > 0
                         ) {
                             this.showFail();
-                            this.errorMessage = "[xXx] Please enter an unused voucher code.";
+                            this.errorMessage = "[xXx] That voucher may have been used already.";
                         } else {
                             this.showValidate();
                             this.errorMessage = "";

--- a/src/pages/Tap.vue
+++ b/src/pages/Tap.vue
@@ -66,9 +66,10 @@ export default {
     },
     methods:  {
         onRecordVoucher: function(event) {
-            this.startSpinner();
+
             //TODO: some proper validation
             if (this.voucherCode !== null && this.voucherCode.length > 0) {
+                this.startSpinner();
                 Store.addVoucherCode(this.sponsorCode.toUpperCase()+this.voucherCode,
                     // Success function
                     function(response) {
@@ -77,11 +78,12 @@ export default {
                             response.data.invalid.length > 0
                         ) {
                             this.showFail();
-                            this.errorMessage = "[xXx]The voucher code you entered is not valid. Please try again.";
+                            this.errorMessage = "[xXx] Please enter a valid voucher code.";
                         } else if (
                             response.data.fail.length > 0
                         ) {
-                            this.errorMessage = "[xXx]The voucher code you entered has previously been submitted. Please try again.";
+                            this.showFail();
+                            this.errorMessage = "[xXx] Please enter an unused voucher code.";
                         } else {
                             this.showValidate();
                             this.errorMessage = "";
@@ -94,6 +96,9 @@ export default {
                     });
                 // Do anyway.
                 this.voucherCode = "";
+            } else {
+              this.showFail();
+              this.errorMessage = "[xXx] Please enter a valid code.";
             }
         },
 

--- a/src/pages/Tap.vue
+++ b/src/pages/Tap.vue
@@ -72,6 +72,7 @@ export default {
                 Store.addVoucherCode(this.sponsorCode.toUpperCase()+this.voucherCode,
                     // Success function
                     function(response) {
+
                         // Add error message for invalid and fail codes.
                         if (
                             response.data.invalid.length > 0
@@ -97,7 +98,7 @@ export default {
                 this.voucherCode = "";
             } else {
               this.showFail();
-              this.errorMessage = "[xXx] Please enter a valid code.";
+              this.errorMessage = "[xXx] Please enter a valid voucher code.";
             }
         },
 

--- a/tests/pages/scan.test.js
+++ b/tests/pages/scan.test.js
@@ -106,7 +106,7 @@ test('Correct error appears when I submit an invalid voucher', async t => {
         .click(submitButton)
     ;
     const errorMessage = await el('.content div.message').innerText;
-    expect(errorMessage).to.contain('The voucher code you entered is not valid. Please try again.');
+    expect(errorMessage).to.contain('Please enter a valid voucher code.');
 });
 
 test('Correct error appears when I submit a duplicate voucher', async t => {
@@ -132,7 +132,7 @@ test('Correct error appears when I submit a duplicate voucher', async t => {
         .click(submitButton)
     ;
     const errorMessage = await el('.message').innerText;
-    expect(errorMessage).to.contain('The voucher code you entered has previously been submitted. Please try again.');
+    expect(errorMessage).to.contain('That voucher may have been used already.');
 });
 
 test('Page displays number of recorded vouchers', async t => {

--- a/tests/pages/scan.test.js
+++ b/tests/pages/scan.test.js
@@ -106,7 +106,7 @@ test('Correct error appears when I submit an invalid voucher', async t => {
         .click(submitButton)
     ;
     const errorMessage = await el('.content div.message').innerText;
-    expect(errorMessage).to.contain('Please enter a valid voucher code.');
+    expect(errorMessage).to.contain('That voucher may have been used already.');
 });
 
 test('Correct error appears when I submit a duplicate voucher', async t => {
@@ -132,7 +132,7 @@ test('Correct error appears when I submit a duplicate voucher', async t => {
         .click(submitButton)
     ;
     const errorMessage = await el('.message').innerText;
-    expect(errorMessage).to.contain('That voucher may have been used already.');
+    expect(errorMessage).to.contain('Please enter a valid voucher code.');
 });
 
 test('Page displays number of recorded vouchers', async t => {

--- a/tests/pages/scan.test.js
+++ b/tests/pages/scan.test.js
@@ -106,7 +106,7 @@ test('Correct error appears when I submit an invalid voucher', async t => {
         .click(submitButton)
     ;
     const errorMessage = await el('.content div.message').innerText;
-    expect(errorMessage).to.contain('That voucher may have been used already.');
+    expect(errorMessage).to.contain('[xXx] Please enter a valid voucher code.');
 });
 
 test('Correct error appears when I submit a duplicate voucher', async t => {
@@ -124,7 +124,7 @@ test('Correct error appears when I submit a duplicate voucher', async t => {
         .click(sponsorBox)
         .pressKey('backspace backspace backspace')
         .typeText(el('#sponsorBox'), 'FAL')
-        .typeText(el('#voucherBox'), '11111111')
+        .typeText(el('#voucherBox'), '1')
     ;
     const submitButton = await el('#submitVoucher');
 
@@ -132,7 +132,7 @@ test('Correct error appears when I submit a duplicate voucher', async t => {
         .click(submitButton)
     ;
     const errorMessage = await el('.message').innerText;
-    expect(errorMessage).to.contain('Please enter a valid voucher code.');
+    expect(errorMessage).to.contain('[xXx] That voucher may have been used already.');
 });
 
 test('Page displays number of recorded vouchers', async t => {

--- a/tests/pages/tap.test.js
+++ b/tests/pages/tap.test.js
@@ -128,7 +128,7 @@ test('Correct error appears when I submit a duplicate voucher', async t => {
         .click(submitVoucher)
     ;
     const errorMessage = await el('.message').innerText;
-    expect(errorMessage).to.contain('The voucher code you entered is not valid. Please try again.');
+    expect(errorMessage).to.contain('Please enter a valid voucher code.');
 });
 
 test('Correct error appears when I submit an invalid voucher', async t => {
@@ -153,7 +153,7 @@ test('Correct error appears when I submit an invalid voucher', async t => {
         .click(submitVoucher)
     ;
     const errorMessage = await el('.message').innerText;
-    expect(errorMessage).to.contain('The voucher code you entered has previously been submitted. Please try again.');
+    expect(errorMessage).to.contain('Please enter an unused voucher code.');
 });
 
 test('I cannot type letters into the voucher input', async t => {

--- a/tests/pages/tap.test.js
+++ b/tests/pages/tap.test.js
@@ -128,7 +128,7 @@ test('Correct error appears when I submit a duplicate voucher', async t => {
         .click(submitVoucher)
     ;
     const errorMessage = await el('.message').innerText;
-    expect(errorMessage).to.contain('Please enter a valid voucher code.');
+    expect(errorMessage).to.contain('That voucher may have been used already.');
 });
 
 test('Correct error appears when I submit an invalid voucher', async t => {
@@ -153,7 +153,7 @@ test('Correct error appears when I submit an invalid voucher', async t => {
         .click(submitVoucher)
     ;
     const errorMessage = await el('.message').innerText;
-    expect(errorMessage).to.contain('That voucher may have been used already.');
+    expect(errorMessage).to.contain('Please enter a valid voucher code.');
 });
 
 test('I cannot type letters into the voucher input', async t => {

--- a/tests/pages/tap.test.js
+++ b/tests/pages/tap.test.js
@@ -119,7 +119,7 @@ test('Correct error appears when I submit a duplicate voucher', async t => {
     await t
         .click(sponsorBox)
         .pressKey('backspace backspace backspace')
-        .typeText(sponsorBox, 'INV')
+        .typeText(sponsorBox, 'FAL')
         .typeText(el('#voucherBox'), '1')
     ;
     const submitVoucher = await el('button#submitVoucher');
@@ -128,7 +128,7 @@ test('Correct error appears when I submit a duplicate voucher', async t => {
         .click(submitVoucher)
     ;
     const errorMessage = await el('.message').innerText;
-    expect(errorMessage).to.contain('Please enter a valid voucher code.');
+    expect(errorMessage).to.contain('[xXx] That voucher may have been used already.');
 });
 
 test('Correct error appears when I submit an invalid voucher', async t => {
@@ -144,7 +144,7 @@ test('Correct error appears when I submit an invalid voucher', async t => {
     await t
         .click(sponsorBox)
         .pressKey('backspace backspace backspace')
-        .typeText(sponsorBox, 'FAL')
+        .typeText(sponsorBox, 'INV')
         .typeText(el('#voucherBox'), '11111111')
     ;
     const submitVoucher = await el('button#submitVoucher');
@@ -153,7 +153,7 @@ test('Correct error appears when I submit an invalid voucher', async t => {
         .click(submitVoucher)
     ;
     const errorMessage = await el('.message').innerText;
-    expect(errorMessage).to.contain('That voucher may have been used already.');
+    expect(errorMessage).to.contain('[xXx] Please enter a valid voucher code.');
 });
 
 test('I cannot type letters into the voucher input', async t => {

--- a/tests/pages/tap.test.js
+++ b/tests/pages/tap.test.js
@@ -128,7 +128,7 @@ test('Correct error appears when I submit a duplicate voucher', async t => {
         .click(submitVoucher)
     ;
     const errorMessage = await el('.message').innerText;
-    expect(errorMessage).to.contain('That voucher may have been used already.');
+    expect(errorMessage).to.contain('Please enter a valid voucher code.');
 });
 
 test('Correct error appears when I submit an invalid voucher', async t => {
@@ -153,7 +153,7 @@ test('Correct error appears when I submit an invalid voucher', async t => {
         .click(submitVoucher)
     ;
     const errorMessage = await el('.message').innerText;
-    expect(errorMessage).to.contain('Please enter a valid voucher code.');
+    expect(errorMessage).to.contain('That voucher may have been used already.');
 });
 
 test('I cannot type letters into the voucher input', async t => {

--- a/tests/pages/tap.test.js
+++ b/tests/pages/tap.test.js
@@ -153,7 +153,7 @@ test('Correct error appears when I submit an invalid voucher', async t => {
         .click(submitVoucher)
     ;
     const errorMessage = await el('.message').innerText;
-    expect(errorMessage).to.contain('Please enter an unused voucher code.');
+    expect(errorMessage).to.contain('That voucher may have been used already.');
 });
 
 test('I cannot type letters into the voucher input', async t => {


### PR DESCRIPTION
Shortened the error messages for now - since the copy is just temporary we might as well have something that fits (in case of any more demos!). Once we decide on the final copy, I'll address the issue of making sure there's enough space to display the messages (already part of another card in tech debt).

Added fix for the spinner button so if you try to submit with no input, you get an error message and the button goes red and resets back to purple.