### PR TITLE
1.0/341 bug offline plugin does not consistently reload fresh builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "css-loader": "^0.25.0",
     "file-loader": "^0.9.0",
     "font-awesome": "^4.7.0",
+    "git-revision-webpack-plugin": "^2.5.1",
     "html-webpack-plugin": "^2.28.0",
     "node-sass": "^4.5.0",
     "offline-plugin": "^4.8.1",

--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,7 @@ import Payment from './pages/Payment.vue';
 import Login from './pages/Login.vue';
 import User from './pages/User.vue';
 
-console.log(BUILDDATE + ' ' + VERSION + ' ' + BRANCH);
+console.info(BUILDDATE + ' ' + VERSION + ' ' + BRANCH);
 
 /*
 route access rules

--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,7 @@ import Payment from './pages/Payment.vue';
 import Login from './pages/Login.vue';
 import User from './pages/User.vue';
 
-console.info(BUILDDATE + ' ' + VERSION + ' ' + BRANCH);
+console.info(BUILDDATE + '\n' + BRANCH + '\n' + VERSION);
 
 /*
 route access rules

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,8 @@ import Payment from './pages/Payment.vue';
 import Login from './pages/Login.vue';
 import User from './pages/User.vue';
 
+console.log(BUILDDATE + ' ' + VERSION + ' ' + BRANCH);
+
 /*
 route access rules
 auth -> true, user MUST be auth'd - friends only

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -24,7 +24,7 @@
         </main>
 
         <div class="footer">
-            <span id="build">{{ buildmsg }}</span>
+            <span id="build">Commit : {{ commitmsg }}</span>
         </div>
     </div>
 </template>
@@ -39,7 +39,7 @@
                 password: null,
                 remember: true,
                 errorMessage : Store.error,
-                buildmsg: VERSION
+                commitmsg: VERSION
             }
         },
         methods: {

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -23,9 +23,7 @@
 
         </main>
 
-        <div class="footer">
-            <span id="build">Commit : {{ commitmsg }}</span>
-        </div>
+        <footer>Commit : {{ commitmsg }}</footer>
     </div>
 </template>
 

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -23,6 +23,9 @@
 
         </main>
 
+        <div class="footer">
+            <span id="build">{{ buildmsg }}</span>
+        </div>
     </div>
 </template>
 
@@ -35,7 +38,8 @@
                 username: null,
                 password: null,
                 remember: true,
-                errorMessage : Store.error
+                errorMessage : Store.error,
+                buildmsg: VERSION
             }
         },
         methods: {

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -242,16 +242,13 @@ header {
   justify-content: space-between;
 }
 
-.footer {
+footer {
   position: absolute;
   right: 0;
   bottom: 0;
   left: 0;
   padding: 0.5rem;
   text-align: center;
-}
-
-#build {
   font-size:0.75em;
   opacity: 0.15;
 }

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -252,9 +252,8 @@ header {
 }
 
 #build {
-  font-size:1em;
+  font-size:0.75em;
   opacity: 0.15;
-  float: right;
 }
 
 .logo {

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -242,6 +242,21 @@ header {
   justify-content: space-between;
 }
 
+.footer {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: 0.5rem;
+  text-align: center;
+}
+
+#build {
+  font-size:1em;
+  opacity: 0.15;
+  float: right;
+}
+
 .logo {
   img {
     padding: 2em 0 1.3em 2em;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 /* "Copyright © 2017, Alexandra Rose Charity (reg. in England and Wales, #00279157)" */
 var path = require('path');
 var webpack = require('webpack');
+var GitRevisionPlugin = require('git-revision-webpack-plugin');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
 var OfflinePlugin = require('offline-plugin');
@@ -11,6 +12,8 @@ if (process.env.NODE_ENV === 'production') {
     var publicPath = '/';
 }
 
+var gitRevisionPlugin = new GitRevisionPlugin();
+
 module.exports = {
     entry: ['babel-polyfill','./src/main.js'],
     output: {
@@ -19,6 +22,12 @@ module.exports = {
         filename: 'build.js?[hash]'
     },
     plugins: [
+        new webpack.DefinePlugin({
+            'VERSION': JSON.stringify(gitRevisionPlugin.version()),
+            'COMMITHASH': JSON.stringify(gitRevisionPlugin.commithash()),
+            'BRANCH': JSON.stringify(gitRevisionPlugin.branch()),
+            'BUILDDATE': JSON.stringify(new Date()),
+        }),
         new HtmlWebpackPlugin({
             filename: 'index.html',
             template: 'index.html',
@@ -95,13 +104,17 @@ module.exports = {
     },
 
     devtool: '#eval-source-map'
-}
+};
 
 if (process.env.NODE_ENV === 'production') {
     module.exports.devtool = '#source-map';
     // http://vue-loader.vuejs.org/en/workflow/production.html
     module.exports.plugins = (module.exports.plugins || []).concat([
         new webpack.DefinePlugin({
+            'VERSION': JSON.stringify(gitRevisionPlugin.version()),
+            'COMMITHASH': JSON.stringify(gitRevisionPlugin.commithash()),
+            'BRANCH': JSON.stringify(gitRevisionPlugin.branch()),
+            'BUILDDATE': JSON.stringify(new Date()),
             'process.env': {
                 NODE_ENV: '"production"'
             }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,10 +14,9 @@ if (process.env.NODE_ENV === 'production') {
 module.exports = {
     entry: ['babel-polyfill','./src/main.js'],
     output: {
-//    path: path.resolve(__dirname, './dist'),
         path: path.resolve(__dirname, './dist'),
         publicPath: publicPath,
-        filename: 'build.js'
+        filename: 'build.js?[hash]'
     },
     plugins: [
         new HtmlWebpackPlugin({
@@ -69,14 +68,14 @@ module.exports = {
                 test: /\.(eot|svg|ttf|woff|woff2)$/,
                 loader: 'file-loader',
                 options: {
-                    name: './fonts/[name].[ext]'
+                    name: './fonts/[name].[ext]?[hash]'
                 }
             },
             {
                 test: /manifest.json/,
                 loader: 'file-loader',
                 options: {
-                    name: '[name].[ext]'
+                    name: '[name].[ext]?[hash]'
                 }
             }
         ]
@@ -117,7 +116,8 @@ if (process.env.NODE_ENV === 'production') {
             minimize: true
         }),
 	new CopyWebpackPlugin([{
-            from: 'src/assets'
+            from: 'src/assets',
+            to: '[name].[ext]?[hash]'
 	}])
     ])
 }


### PR DESCRIPTION
The [hash] parts on the new filenames change every build, *thus* when we push a new build, the appcache and service worker should notice!
There's now a console.log on startup that prints the date, short hash and branchname to the console.log - I'm hoping that should be enough for testers to check that the current build is in place. 