### PR TITLE
1.0/377 success bug

### DIFF
--- a/src/components/Queue.vue
+++ b/src/components/Queue.vue
@@ -137,6 +137,7 @@ export default {
                 var fail = '';
                 var invalid = '';
 
+                // Construct the feedback message.
                 if (data.success.length === 1) {
                     success = "1 voucher was accepted, ";
                 } else {
@@ -163,6 +164,7 @@ export default {
                 ;
 
                 this.showValidate();
+                // Update the parent component so that it can hide the not enough signal message
                 this.$emit('update', this.clearMessage);
 
             }.bind(this),

--- a/src/components/Queue.vue
+++ b/src/components/Queue.vue
@@ -164,7 +164,7 @@ export default {
                 ;
 
                 this.showValidate();
-                // Update the parent component so that it can hide the not enough signal message
+                // Send out an update which will be picked up in tap, so that it can hide the not enough signal message
                 this.$emit('update', this.clearMessage);
 
             }.bind(this),

--- a/src/components/Queue.vue
+++ b/src/components/Queue.vue
@@ -155,7 +155,6 @@ export default {
                     invalid = "and " + data.invalid.length + " were invalid.";
                 }
 
-                this.showValidate();
                 this.message
                     = "Thanks! Your queue has been successfully submitted. "
                     + success
@@ -163,6 +162,7 @@ export default {
                     + invalid
                 ;
 
+                this.showValidate();
                 this.$emit('update', this.clearMessage);
 
             }.bind(this),

--- a/src/components/Queue.vue
+++ b/src/components/Queue.vue
@@ -2,7 +2,7 @@
     <transition name="fade"  v-if="currentlyShown">
     <div class="content narrow queuedVouchers">
 
-        <h1 v-on:click="collapsed = !collapsed" class="expandable queue" v-bind:class="{'expanded' : !collapsed}">Queued vouchers d</h1>
+        <h1 v-on:click="collapsed = !collapsed" class="expandable queue" v-bind:class="{'expanded' : !collapsed}">Queued vouchers</h1>
 
         <transition name="fade" v-if="show">
             <div v-if="!message" class="goodmessage queue">
@@ -144,15 +144,15 @@ export default {
                 }
 
                 if (data.fail.length === 1) {
-                    fail = ", 1 was rejected ";
+                    fail = ", 1 was a duplicate ";
                 } else {
-                    fail = data.fail.length + " were rejected ";
+                    fail = data.fail.length + " were duplicates ";
                 }
 
                 if (data.invalid.length === 1) {
-                    invalid = " and 1 voucher was invalid.";
+                    invalid = "and 1 was invalid.";
                 } else {
-                    invalid = data.invalid.length + " vouchers were invalid.";
+                    invalid = "and " + data.invalid.length + " were invalid.";
                 }
 
                 this.showValidate();

--- a/src/components/Queue.vue
+++ b/src/components/Queue.vue
@@ -144,7 +144,7 @@ export default {
                 }
 
                 if (data.fail.length === 1) {
-                    fail = ", 1 was a duplicate ";
+                    fail = " 1 was a duplicate ";
                 } else {
                     fail = data.fail.length + " were duplicates ";
                 }

--- a/src/components/Queue.vue
+++ b/src/components/Queue.vue
@@ -2,7 +2,7 @@
     <transition name="fade"  v-if="currentlyShown">
     <div class="content narrow queuedVouchers">
 
-        <h1 v-on:click="collapsed = !collapsed" class="expandable queue" v-bind:class="{'expanded' : !collapsed}">Queued vouchers</h1>
+        <h1 v-on:click="collapsed = !collapsed" class="expandable queue" v-bind:class="{'expanded' : !collapsed}">Queued vouchers d</h1>
 
         <transition name="fade" v-if="show">
             <div v-if="!message" class="goodmessage queue">
@@ -33,7 +33,7 @@
                 </div>
 
                 <!-- Tab row -->
-                <div v-for="voucher in vouchers" class="tab row">
+                <div class="tab row" v-for="voucher in vouchers">
                     <label>
                         <div class="row-code">
                             <div>{{ voucher }}</div>
@@ -67,6 +67,7 @@ export default {
             validate: false,
             fail: false,
             message: '',
+            clearMessage: true
         }
     },
     watch: {
@@ -106,7 +107,6 @@ export default {
             this.spinner = false;
             this.validate = true;
 
-            this.message = "Thanks! We've successfully submitted your queued vouchers.";
             setTimeout(function() {
                 this.validate = false;
                 this.message = '';
@@ -127,12 +127,24 @@ export default {
         onSubmitQueue: function() {
             this.startSpinner();
 
-            Store.transitionVouchers('collect', this.vouchers, function() {
+            Store.transitionVouchers('collect', this.vouchers, function(response) {
                 // The server has processed our list, clear it.
                 Store.clearVouchers();
                 Store.getRecVouchers();
 
-                this.showValidate();
+                    var data = response.data;
+                    this.showValidate();
+                    this.message
+                        = "Thanks! "
+                        + data.success.length
+                        + " vouchers were accepted, "
+                        + data.fail.length
+                        + " were rejected and "
+                        + data.invalid.length
+                        + " were invalid."
+                    ;
+                    this.$emit('update', this.clearMessage);
+
             }.bind(this),
             function() {
                 this.showFail();

--- a/src/components/Queue.vue
+++ b/src/components/Queue.vue
@@ -132,18 +132,38 @@ export default {
                 Store.clearVouchers();
                 Store.getRecVouchers();
 
-                    var data = response.data;
-                    this.showValidate();
-                    this.message
-                        = "Thanks! "
-                        + data.success.length
-                        + " vouchers were accepted, "
-                        + data.fail.length
-                        + " were rejected and "
-                        + data.invalid.length
-                        + " were invalid."
-                    ;
-                    this.$emit('update', this.clearMessage);
+                var data = response.data;
+                var success = '';
+                var fail = '';
+                var invalid = '';
+
+                if (data.success.length === 1) {
+                    success = "1 voucher was accepted, ";
+                } else {
+                    success = data.success.length + " vouchers were accepted, ";
+                }
+
+                if (data.fail.length === 1) {
+                    fail = ", 1 was rejected ";
+                } else {
+                    fail = data.fail.length + " were rejected ";
+                }
+
+                if (data.invalid.length === 1) {
+                    invalid = " and 1 voucher was invalid.";
+                } else {
+                    invalid = data.invalid.length + " vouchers were invalid.";
+                }
+
+                this.showValidate();
+                this.message
+                    = "Thanks! Your queue has been successfully submitted. "
+                    + success
+                    + fail
+                    + invalid
+                ;
+
+                this.$emit('update', this.clearMessage);
 
             }.bind(this),
             function() {

--- a/src/pages/Scan.vue
+++ b/src/pages/Scan.vue
@@ -8,7 +8,7 @@
 
                 <form id="textVoucher" v-on:submit.prevent>
                     <transition name="fade">
-                        <div v-if="errorMessage" class="message">{{ errorMessage }}</div>
+                        <div v-if="errorMessage && (!showQueueMsg)" class="message">{{ errorMessage }}</div>
                     </transition>
 
                     <label for="sponsorBox" id="lblSponsorBox" class="hidden">Sponsor Code</label>
@@ -47,7 +47,7 @@
             </div>
 
             <div>
-                <queue ></queue>
+                <queue :value="queueMsg" @update="queueMessage"></queue>
             </div>
 
         </main>
@@ -81,6 +81,7 @@ export default {
             validate: false,
             fail: false,
             queued: false,
+            queueMsg: false
         }
     },
     watch: {
@@ -91,6 +92,9 @@ export default {
         }
     },
     methods:  {
+        queueMessage (v) {
+            this.queueMsg = v
+        },
         onRecordVoucher: function(event) {
             //TODO: some proper validation
             if (this.voucherCode !== null && this.voucherCode.length > 0) {
@@ -112,17 +116,6 @@ export default {
                                 this.errorMessage = "That voucher may have been used already.";
                             }
 
-                        } else if (data.invalid.length + data.fail.length > 1) {
-                            // rough multifailure manager
-                            this.showFail();
-                            this.errorMessage
-                                = data.success.length
-                                + " accepted, "
-                                + data.fail.length
-                                + " rejected and "
-                                + data.invalid.length
-                                + " were invalid."
-                            ;
                         } else {
                             // all in!
                             this.showValidate();
@@ -258,6 +251,11 @@ export default {
             // There's also "event.key" (string), which MDN thinks is better;
             var charCode = event.keyCode ? event.keyCode : event.charCode;
             return String.fromCharCode(charCode);
+        }
+    },
+    computed: {
+        showQueueMsg() {
+          return this.queueMsg;
         }
     },
     mounted: function() {

--- a/src/pages/Scan.vue
+++ b/src/pages/Scan.vue
@@ -47,7 +47,7 @@
             </div>
 
             <div>
-                <queue :value="queueMsg" @update="queueMessage"></queue>
+                <queue @update="queueMessage"></queue>
             </div>
 
         </main>

--- a/src/pages/Tap.vue
+++ b/src/pages/Tap.vue
@@ -8,7 +8,7 @@
 
                 <form id="textVoucher" v-on:submit.prevent>
                     <transition name="fade">
-                        <div v-if="errorMessage" class="message">{{ errorMessage }}</div>
+                        <div v-if="errorMessage && (!showQueueMsg)" class="message">{{ errorMessage }}</div>
                     </transition>
                     <label for="sponsorBox" id="lblSponsorBox" class="hidden">Sponsor code</label>
                     <label for="voucherBox" id="lblVoucherBox" class="hidden">Voucher code</label>
@@ -45,7 +45,7 @@
            </div>
 
             <div>
-                <queue></queue>
+                <queue :value="queueMsg" @update="queueMessage"></queue>
             </div>
 
         </main>
@@ -77,10 +77,14 @@ export default {
             spinner: false,
             validate: false,
             fail: false,
-            queued: false
+            queued: false,
+            queueMsg: false
         }
     },
     methods: {
+        queueMessage (v) {
+            this.queueMsg = v
+        },
         onRecordVoucher: function(event) {
             //TODO: some proper validation
             if (this.voucherCode !== null && this.voucherCode.length > 0) {
@@ -246,6 +250,11 @@ export default {
             // There's also "event.key" (string), which MDN thinks is better;
             var charCode = event.keyCode ? event.keyCode : event.charCode;
             return String.fromCharCode(charCode);
+        }
+    },
+    computed: {
+        showQueueMsg() {
+          return this.queueMsg;
         }
     },
     mounted: function() {

--- a/src/pages/Tap.vue
+++ b/src/pages/Tap.vue
@@ -4,13 +4,13 @@
 
             <div class="content narrow">
 
-                <h1>Type a voucher code f</h1>
+                <h1>Type a voucher code</h1>
 
                 <form id="textVoucher" v-on:submit.prevent>
                     <transition name="fade">
                         <div v-if="errorMessage && (!showQueueMsg)" class="message">{{ errorMessage }}</div>
                     </transition>
-                    
+
                     <label for="sponsorBox" id="lblSponsorBox" class="hidden">Sponsor code</label>
                     <label for="voucherBox" id="lblVoucherBox" class="hidden">Voucher code</label>
 

--- a/src/pages/Tap.vue
+++ b/src/pages/Tap.vue
@@ -4,12 +4,13 @@
 
             <div class="content narrow">
 
-                <h1>Type a voucher code</h1>
+                <h1>Type a voucher code f</h1>
 
                 <form id="textVoucher" v-on:submit.prevent>
                     <transition name="fade">
                         <div v-if="errorMessage && (!showQueueMsg)" class="message">{{ errorMessage }}</div>
                     </transition>
+                    
                     <label for="sponsorBox" id="lblSponsorBox" class="hidden">Sponsor code</label>
                     <label for="voucherBox" id="lblVoucherBox" class="hidden">Voucher code</label>
 
@@ -106,17 +107,6 @@ export default {
                                 this.errorMessage = "That voucher may have been used already.";
                             }
 
-                        } else if (data.invalid.length + data.fail.length > 1) {
-                            // rough multifailure manager
-                            this.showFail();
-                            this.errorMessage
-                                = data.success.length
-                                + " accepted, "
-                                + data.fail.length
-                                + " rejected and "
-                                + data.invalid.length
-                                + " were invalid."
-                            ;
                         } else {
                             // all in!
                             this.showValidate();

--- a/src/pages/Tap.vue
+++ b/src/pages/Tap.vue
@@ -46,7 +46,7 @@
            </div>
 
             <div>
-                <queue :value="queueMsg" @update="queueMessage"></queue>
+                <queue @update="queueMessage"></queue>
             </div>
 
         </main>

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -425,10 +425,6 @@ h1.expandable {
   text-align: center;
 }
 
-#registeredVouchers ul {
-  padding-left: 1em;
-}
-
 .link {
   text-decoration: none;
   color: $arc_rose;
@@ -541,7 +537,7 @@ h1.expandable.queue {
 }
 
 .goodmessage {
-  padding: 0.5rem 0;
+  padding-top: 1em;
 }
 
 

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -527,8 +527,13 @@ button.queuedVouchers {
   }
 }
 
-label#queuedVouchers {
-  height: initial;
+.queuedVouchers .voucher-list {
+  font-size: 1em;
+  label {
+    height: initial;
+    line-height: 2;
+  }
+}
 
 label#lblSponsorBox {
   height: 0;

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -527,6 +527,9 @@ button.queuedVouchers {
   }
 }
 
+label#queuedVouchers {
+  height: initial;
+
 label#lblSponsorBox {
   height: 0;
 }

--- a/src/store.js
+++ b/src/store.js
@@ -201,11 +201,11 @@ store.mergeRecVouchers = function (replacements) {
 /**
  * Adds a voucher code and submits it.
  */
-store.addVoucherCode = function (voucherCode, success, failure) {
+store.addVoucherCode = function (voucherCode, success, failure, invalid) {
     this.trader.vouchers.push(voucherCode);
     // Store the whole trader
     this.setLocalStorageFromUserTraders();
-    this.transitionVouchers('collect', this.trader.vouchers, success, failure);
+    this.transitionVouchers('collect', this.trader.vouchers, success, failure, invalid);
 };
 
 /**

--- a/src/store.js
+++ b/src/store.js
@@ -201,11 +201,11 @@ store.mergeRecVouchers = function (replacements) {
 /**
  * Adds a voucher code and submits it.
  */
-store.addVoucherCode = function (voucherCode, success, failure, invalid) {
+store.addVoucherCode = function (voucherCode, success, failure) {
     this.trader.vouchers.push(voucherCode);
     // Store the whole trader
     this.setLocalStorageFromUserTraders();
-    this.transitionVouchers('collect', this.trader.vouchers, success, failure, invalid);
+    this.transitionVouchers('collect', this.trader.vouchers, success, failure);
 };
 
 /**

--- a/src/store.js
+++ b/src/store.js
@@ -211,7 +211,7 @@ store.addVoucherCode = function (voucherCode, success, failure) {
 /**
  * Transition request the recorded vouchers list to pending
  */
-store.pendRecVouchers = function (success,failure) {
+store.pendRecVouchers = function (success, failure) {
     // The [0] is vue wierdness
     var voucherCodes = this.trader.recVouchers[0].map(function(voucher) {
         return voucher.code;


### PR DESCRIPTION
This PR is for [this card](https://trello.com/c/d3k6wtpp/377-bug-the-success-message-to-user-on-submit-voucher-queue-is-misleading-we-need-to-clear-previous-not-enough-signal-error-too)

Probably isn't the most elegant code, but the queue is now functioning as it should - as far as I can tell!

* The 'Not enough signal, voucher queued' message now clears when you click the the 'Submit queued vouchers' button.
* On successful queue submission, a more detailed error message displays, letting the user know how many vouchers were accepted, duplicates or invalid.
* Invalid vouchers weren't being counted properly (they were just undefined), these are now counted and displayed in the feedback message
* Moved queue feedback code out of tap and scan, and into the queue component
* Tweaked styling for the voucher code list