### PR TITLE
1.0/red errors

### DIFF
--- a/src/components/Queue.vue
+++ b/src/components/Queue.vue
@@ -5,11 +5,14 @@
         <h1 v-on:click="collapsed = !collapsed" class="expandable queue" v-bind:class="{'expanded' : !collapsed}">Queued vouchers</h1>
 
         <transition name="fade" v-if="show">
-            <div v-if="!message" class="goodmessage queue">
-                You have <strong>{{ vouchers.length }}</strong> vouchers in your queue.
+            <div v-if="fail && message" class="goodmessage error">
+                {{ message }}
             </div>
             <div v-if="message" class="goodmessage queue">
                 {{ message }}
+            </div>
+            <div v-else class="goodmessage queue">
+                You have <strong>{{ vouchers.length }}</strong> vouchers in your queue.
             </div>
         </transition>
 

--- a/src/components/Queue.vue
+++ b/src/components/Queue.vue
@@ -5,13 +5,13 @@
         <h1 v-on:click="collapsed = !collapsed" class="expandable queue" v-bind:class="{'expanded' : !collapsed}">Queued vouchers</h1>
 
         <transition name="fade" v-if="show">
-            <div v-if="fail && message" class="goodmessage error">
+            <div v-if="fail && message" class="message error">
                 {{ message }}
             </div>
-            <div v-if="message" class="goodmessage queue">
+            <div v-if="message" class="message">
                 {{ message }}
             </div>
-            <div v-else class="goodmessage queue">
+            <div v-else class="message">
                 You have <strong>{{ vouchers.length }}</strong> vouchers in your queue.
             </div>
         </transition>

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -7,7 +7,7 @@
 
                 <h1>Log In</h1>
 
-                <transition name="fade"><div v-if="errorMessage" class="message">{{ errorMessage }}</div></transition>
+                <transition name="fade"><div v-if="errorMessage" class="message error">{{ errorMessage }}</div></transition>
 
                 <div>
                     <form id="loginForm" v-on:submit.prevent="onLogin">

--- a/src/pages/Scan.vue
+++ b/src/pages/Scan.vue
@@ -8,7 +8,7 @@
 
                 <form id="textVoucher" v-on:submit.prevent>
                     <transition name="fade">
-                        <div v-if="errorMessage" class="message">{{ errorMessage }}</div>
+                        <div v-if="errorMessage" class="message error">{{ errorMessage }}</div>
                     </transition>
 
                     <label for="sponsorBox" id="lblSponsorBox" class="hidden">Sponsor Code</label>

--- a/src/pages/Tap.vue
+++ b/src/pages/Tap.vue
@@ -8,7 +8,7 @@
 
                 <form id="textVoucher" v-on:submit.prevent>
                     <transition name="fade">
-                        <div v-if="errorMessage" class="message">{{ errorMessage }}</div>
+                        <div v-if="errorMessage" class="message error">{{ errorMessage }}</div>
                     </transition>
                     <label for="sponsorBox" id="lblSponsorBox" class="hidden">Sponsor code</label>
                     <label for="voucherBox" id="lblVoucherBox" class="hidden">Voucher code</label>

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -537,16 +537,8 @@ label#lblSponsorBox {
 
 // Queued voucher list
 h1.expandable.queue {
-  margin-bottom: 0;
+  margin-bottom: 0.5rem;
 }
-
-.goodmessage {
-  padding: 0.5rem 0;
-  &.error {
-    color: $arc_error;
-  }
-}
-
 
 /* --------------------------------------------------------------
 

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -542,6 +542,9 @@ h1.expandable.queue {
 
 .goodmessage {
   padding: 0.5rem 0;
+  &.error {
+    color: $arc_error;
+  }
 }
 
 


### PR DESCRIPTION
https://trello.com/c/77e3go6m/378-error-messages-should-be-in-red-information-messages-should-stay-in-black

Just checked and it shouldn't mess up @gingerbreadpup 's PR as the message that returns the successful/failed vouchers will never (for now anyway) be an error message.

🐰 