### PR TITLE
Prevent the enter key sent from the scanner from causing the form to …

### DIFF
--- a/src/pages/Scan.vue
+++ b/src/pages/Scan.vue
@@ -15,6 +15,7 @@
                     <label for="voucherBox" id="lblVoucherBox" class="hidden">Voucher Code</label>
                     <div class="input-box">
                         <input id="sponsorBox"
+                            @keydown.enter.prevent
                             @keypress='onKeypressSponsorBox'
                             type="text"
                             v-model="sponsorCode"
@@ -86,7 +87,7 @@ export default {
     watch: {
         voucherCode : function(code) {
             if (code.length === parseInt(this.$refs.voucherBox.getAttribute("maxlength"))) {
-                this.$refs.submitVoucher.click();
+                this.onRecordVoucher();
             }
         }
     },
@@ -145,6 +146,7 @@ export default {
                 // Do anyway.
                 this.voucherCode = "";
                 this.sponsorCode = "";
+
                 this.$refs.sponsorBox.focus();
             } else {
               this.showFail();

--- a/src/pages/Scan.vue
+++ b/src/pages/Scan.vue
@@ -146,7 +146,6 @@ export default {
                 // Do anyway.
                 this.voucherCode = "";
                 this.sponsorCode = "";
-
                 this.$refs.sponsorBox.focus();
             } else {
               this.showFail();


### PR DESCRIPTION
…be submitted twice

I also changed the watch event so we call the"onRecordVoucher" method directly for the sake of clarity and consistency.