### PR TITLE
1.1/445 expandability improvements

### DIFF
--- a/src/components/Queue.vue
+++ b/src/components/Queue.vue
@@ -2,7 +2,7 @@
     <transition name="fade"  v-if="currentlyShown">
     <div class="content narrow queuedVouchers">
 
-        <h1 v-on:click="collapsed = !collapsed" class="expandable queue" v-bind:class="{'expanded' : !collapsed}">Queued vouchers</h1>
+        <h1>Queued vouchers</h1>
 
         <transition name="fade" v-if="show">
             <div v-if="fail && message" class="message error">
@@ -15,6 +15,8 @@
                 [xXx]You have <strong>{{ vouchers.length }}</strong> voucher<span v-if="vouchers.length > 1">s</span> in your queue. Queued vouchers will be checked when you submit your queue.
             </div>
         </transition>
+
+        <div v-on:click="collapsed = !collapsed" class="expandable queue" v-bind:class="{'expanded' : !collapsed}"><i class="fa fa-list" aria-hidden="true"></i></div>
 
         <button id="submitQueuedVouchers"
             class="cta queuedVouchers"

--- a/src/pages/Payment.vue
+++ b/src/pages/Payment.vue
@@ -3,40 +3,48 @@
         <main class="container fullwidth" id="payment">
 
             <div class="content fullwidth">
-                <h1 v-if="vouchersAdded" v-on:click="collapsed = !collapsed" class="expandable" v-bind:class="{'expanded' : !collapsed}">You can request payment for <strong>{{ voucherCount }}</strong> voucher<span v-if="voucherCount > 1">s</span>.</h1>
-                <h1 v-else>There are no vouchers to request payment for. Add some!</h1>
 
-                <div class="list-wrapper" v-bind:class="{'is-collapsed' : collapsed }">
+                <div v-if="vouchersAdded">
 
-                    <div class="voucher-list" id="registeredVouchers" v-if="vouchersAdded">
+                    <h1>You can request payment for <strong>{{ voucherCount }}</strong> voucher<span v-if="voucherCount > 1">s</span>.</h1>
 
-                        <!-- Tab header -->
-                        <div class="tab thead">
-                            <label>
-                                <div class="row-code">
-                                    <div>Voucher code</div>
-                                    <div>Voucher added on</div>
-                                </div>
-                            </label>
-                        </div>
+                    <div v-on:click="collapsed = !collapsed" class="expandable" v-bind:class="{'expanded' : !collapsed}"><i class="fa fa-list" aria-hidden="true"></i></div>
 
-                        <!-- Tab row -->
-                        <div class="tab row" v-for="recVoucher in recVouchers[0]">
-                            <label>
-                                <div class="row-code">
-                                    <div>{{ recVoucher.code }}</div>
-                                    <div>{{ recVoucher.updated_at }}</div>
-                                </div>
-                            </label>
+                    <div class="list-wrapper" v-bind:class="{'is-collapsed' : collapsed }">
+
+                        <div class="voucher-list" id="registeredVouchers" v-if="vouchersAdded">
+
+                            <!-- Tab header -->
+                            <div class="tab thead">
+                                <label>
+                                    <div class="row-code">
+                                        <div>Voucher code</div>
+                                        <div>Voucher added on</div>
+                                    </div>
+                                </label>
+                            </div>
+
+                            <!-- Tab row -->
+                            <div class="tab row" v-for="recVoucher in recVouchers[0]">
+                                <label>
+                                    <div class="row-code">
+                                        <div>{{ recVoucher.code }}</div>
+                                        <div>{{ recVoucher.updated_at }}</div>
+                                    </div>
+                                </label>
+                            </div>
+
                         </div>
 
                     </div>
 
+                    <instructions></instructions>
+
+                    <button id="requestPayment" v-on:click="onRequestPayment">Request payment</button>
+
                 </div>
 
-                <instructions></instructions>
-
-                <button id="requestPayment" v-if="vouchersAdded" v-on:click="onRequestPayment">Request payment</button>
+                <div v-else><h1>There are no vouchers to request payment for. Add some!</h1></div>
 
             </div>
 

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -353,9 +353,9 @@ header {
 
 // Add top margin to pages which have the row of icons
 #tap.container,
-#tap .expandable,
-#scan .expandable,
-#scan.container {
+#scan.container,
+#tap h1,
+#scan h1 {
   margin-top: 2.5em;
 }
 
@@ -370,20 +370,23 @@ header {
   }
 }
 
-h1.expandable {
+.expandable {
   cursor: pointer;
-  margin-bottom: 1.5em;
-  &:before {
-    font-weight: bold;
-    font-family: FontAwesome;
-    content: "\f0da";
-    padding-right: 15px;
+  margin: 1em 0;
+  font-weight: bold;
+  text-decoration: underline;
+  &:hover {
+    color: $arc_rose;
   }
-  &.expanded:before {
-    font-weight: bold;
-    font-family: FontAwesome;
-    content: "\f0d7";
+  .fa {
+    font-size: 1rem;
     padding-right: 10px;
+  }
+  &:after {
+    content: "View your voucher list";
+  }
+  &.expanded:after {
+    content: "Hide your voucher list";
   }
 }
 

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -388,6 +388,12 @@ header {
   &.expanded:after {
     content: "Hide your voucher list";
   }
+  &.queue:after {
+    content: "View your queued vouchers";
+  }
+  &.queue.expanded:after {
+    content: "Hide your queued vouchers";
+  }
 }
 
 // styling for the div which contains both text fields for adding vouchers

--- a/tests/pages/account.test.js
+++ b/tests/pages/account.test.js
@@ -44,6 +44,18 @@ test('Requested payments accordion exists', async t => {
     expect(paymentsAccordion).to.be.ok;
 });
 
+test('Payment history list icon is present in table row', async t => {
+    await t
+        .typeText('#userName', 'email@example.com')
+        .typeText('#userPassword', 'secretpass')
+        .click('button')
+        .click("#radio-0")
+        .click('button#continue')
+    ;
+    const voucherExpander = await el('.fa-list').exists;
+    expect(voucherExpander).to.be.ok;
+});
+
 test('Email history button exists', async t => {
     await t
         .typeText('#userName', 'email@example.com')

--- a/tests/pages/payment.test.js
+++ b/tests/pages/payment.test.js
@@ -17,9 +17,9 @@ test('Pending vouchers is consistent throughout app', async t =>{
         .click("#radio-0")
         .click('button#continue')
     ;
-    const paymentVoucherCount = await el('.expandable').child('strong').innerText;
+    const paymentVoucherCount = await el('h1').child('strong').innerText;
     const addVoucherPage = await el('nav > ul').child(0);
-    
+
     await t
         .click(addVoucherPage)
     ;

--- a/tests/pages/payment.test.js
+++ b/tests/pages/payment.test.js
@@ -27,6 +27,18 @@ test('Pending vouchers is consistent throughout app', async t =>{
     expect(paymentVoucherCount && navVoucherCount).to.contain('2');
 });
 
+test('Voucher list show/hide expander is present', async t => {
+    await t
+        .typeText('#userName', 'email@example.com')
+        .typeText('#userPassword', 'secretpass')
+        .click('button')
+        .click("#radio-0")
+        .click('button#continue')
+    ;
+    const voucherExpander = await el('.expandable').exists;
+    expect(voucherExpander).to.be.ok;
+});
+
 test('Voucher code list exists', async t => {
     await t
         .typeText('#userName', 'email@example.com')


### PR DESCRIPTION
Queue section: 'Queued vouchers' is now just a heading. Below it is a list icon and the text 'view your queued vouchers', which shows and hides the queued vouchers.

Payment page: Same as above, the heading is just a heading and below it is a show/hide list icon and text which says 'View your voucher list'.

These changes, along with the PR for the account page, should make the expandability functionality consistent and more obvious across the app. Card [here.](https://trello.com/c/KvcFPqKa/445-make-expandability-function-more-obvious-and-consistent)