### PR TITLE
1.1/416 as trader i would like to see a default prefix relevant to my area so that my voucher code entry is faster

### DIFF
--- a/src/pages/Tap.vue
+++ b/src/pages/Tap.vue
@@ -75,7 +75,7 @@ export default {
     },
     data: function() {
         return {
-            sponsorCode : "RVNT",
+            sponsorCode : Store.trader.market.sponsor_shortcode,
             voucherCode : "",
             vouchers : Store.trader.vouchers,
             recVouchers : Store.trader.recVouchers,

--- a/tests/pages/tap.test.js
+++ b/tests/pages/tap.test.js
@@ -220,4 +220,36 @@ test('Voucher link is working', async t => {
     ;
     const pagePath = await t.eval(() => window.location);
     expect(pagePath.pathname).eql('/payment');
-})
+});
+
+test('The correct sponsor code for the selected trader is loaded', async t => {
+    await t
+        .typeText('#userName', 'email@example.co.uk')
+        .typeText('#userPassword', 'secretpass')
+        .click('button')
+        .click('input#radio-0')
+        .pressKey('enter')
+    ;
+
+    // Check the sponsor code for the first user (RVNT: see fixtures).
+    const sponsorCode = await el('#sponsorBox').value;
+    expect(sponsorCode).eql('RVNT');
+
+    // Switch trader.
+    const traderLink = await el('.profile-bar a');
+
+    await t
+        .click(traderLink)
+    ;
+    const secondTrader = await el('input#radio-1');
+
+    await t
+        .click(secondTrader)
+        .pressKey('enter')
+    ;
+
+    // Check the sponsor code for the second user (KMJG: see fixtures).
+    const secondUserSponsorCode = await el('#sponsorBox').value;
+    expect(secondUserSponsorCode).eql('KMJG');
+
+});


### PR DESCRIPTION
I believe that it really is this simple. It will default to an empty string if for some reason the market object isn't included in the trader request (which shouldn't happen anyway).