### PR TITLE
alter Rsync to copy entire dist directory contents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ before_script:
 before_deploy:
 - npm run build
 - cp src/robots.txt dist/
-- cp src/.htaccess dist/ # We are copying the `.htaccess` file here because webpack-copy didn't function correctly.
+- cp src/.htaccess dist/
 deploy:
   provider: script
   skip_cleanup: true
-  script: rsync -r --delete-after --quiet $TRAVIS_BUILD_DIR/dist/* $DEPLOY_USER@$DEPLOY_IP:/var/www/$DEPLOY_DIR
+  script: rsync -r --delete-after --quiet $TRAVIS_BUILD_DIR/dist/ $DEPLOY_USER@$DEPLOY_IP:/var/www/$DEPLOY_DIR/
   on:
     branch: 1.1/release
 env:


### PR DESCRIPTION
becuase '*' unpacks to not include '.' files BUT adding / to dist and deploy_dir does.