### PR TITLE
1.2/1533 Upgrade third-party dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: node_js
 node_js:
-- '7'
+- 'lts/*'
 sudo: required
 dist: trusty
-before_install:
-  - npx --version
 addons:
-  firefox: '53.0'  # We are setting the version to 53 until TestCafe supports v54+
+  firefox: latest  # We are setting the version to 53 until TestCafe supports v54+
   chrome: stable
   ssh_known_hosts: 46.101.18.83
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
 - '7'
 sudo: required
 dist: trusty
+before_install:
+  - npx --version
 addons:
   firefox: '53.0'  # We are setting the version to 53 until TestCafe supports v54+
   chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
     sources:
     - google-chrome
     packages:
-    - google-chrome-stable fluxbox
+    - fluxbox
 before_script:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: required
 dist: trusty
 addons:
   firefox: '53.0'  # We are setting the version to 53 until TestCafe supports v54+
+  chrome: stable
   ssh_known_hosts: 46.101.18.83
   apt:
     sources:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "testcafe chrome,firefox ./tests/*/*.test.js --app 'cross-env NODE_ENV=development webpack-dev-server'"
   },
   "dependencies": {
-    "axios": "^0.16.1",
+    "axios": "^0.19.2",
     "axios-mock-adapter": "^1.8.1",
     "babel-polyfill": "^6.23.0",
     "normalize.css": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node-sass": "^4.5.0",
     "offline-plugin": "^4.8.1",
     "sass-loader": "^5.0.1",
-    "testcafe": "^0.15.0",
+    "testcafe": "^0.23.3",
     "testcafe-vue-selectors": "^1.0.3",
     "vue-loader": "^11.1.4",
     "vue-template-compiler": "^2.2.1",
@@ -45,13 +45,10 @@
     "webpack-dev-server": "^2.2.0"
   },
   "resolutions": {
-    "atob": "2.1.0",
     "deep-extend": "0.5.1",
     "js-yaml": "3.13.1",
-    "lodash": "4.17.12",
-    "mime": "2.0.3",
+    "lodash": "~4.17.12",
     "serialize-javascript": "2.1.1",
-    "tough-cookie": "2.3.3",
     "uglify-js": "2.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,8 +45,13 @@
     "webpack-dev-server": "^2.2.0"
   },
   "resolutions": {
+    "atob": "2.1.0",
+    "deep-extend": "0.5.1",
     "js-yaml": "3.13.1",
     "lodash": "4.17.12",
-    "tough-cookie": "2.3.3"
+    "mime": "2.0.3",
+    "serialize-javascript": "2.1.1",
+    "tough-cookie": "2.3.3",
+    "uglify-js": "2.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Neontribe Ltd",
   "private": true,
   "scripts": {
+    "preinstall": "npx npm-force-resolutions",
     "dev": "cross-env NODE_ENV=development webpack-dev-server --open --hot",
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules --display-error-details",
     "test": "testcafe chrome,firefox ./tests/*/*.test.js --app 'cross-env NODE_ENV=development webpack-dev-server'"
@@ -15,6 +16,7 @@
     "axios-mock-adapter": "^1.8.1",
     "babel-polyfill": "^6.23.0",
     "normalize.css": "^7.0.0",
+    "npm-force-resolutions": "0.0.3",
     "route-parser": "0.0.5",
     "vue": "^2.2.1",
     "vue-axios": "^2.0.2",
@@ -41,5 +43,10 @@
     "vue-template-compiler": "^2.2.1",
     "webpack": "^2.2.0",
     "webpack-dev-server": "^2.2.0"
+  },
+  "resolutions": {
+    "js-yaml": "3.13.1",
+    "lodash": "4.17.12",
+    "tough-cookie": "2.3.3"
   }
 }

--- a/tests/pages/tap.test.js
+++ b/tests/pages/tap.test.js
@@ -101,7 +101,7 @@ test('I can type and submit a voucher code', async t => {
         .typeText(el('#voucherBox'), '12345678')
         .click('#submitVoucher')
         // Check the box is clear again.
-        .expect(el('#voucherBox').value, '')
+        .expect(el('#voucherBox').value).eql('')
     ;
 
 });
@@ -173,7 +173,7 @@ test('I cannot type letters into the voucher input', async t => {
 
     await t
         .typeText(voucherBox, 'HELLO')
-        .expect(voucherBox.value, '')
+        .expect(voucherBox.value).eql('')
     ;
 });
 
@@ -191,7 +191,7 @@ test('I cannot type numbers into the sponsor input', async t => {
         .click(sponsorBox)
         .pressKey('backspace backspace backspace')
         .typeText(sponsorBox, '123')
-        .expect(sponsorBox.value, '')
+        .expect(sponsorBox.value).eql('')
     ;
 });
 


### PR DESCRIPTION
## Trello card - [https://trello.com/c/S5lICSJF/1533-upgrade-third-party-dependencies](https://trello.com/c/S5lICSJF/1533-upgrade-third-party-dependencies)

## Overview 
- running `npm install` revelead 19 vulnerabilities (4 low, 8 moderate, 7 high)
- the reason behind is because some top-level dependencies have not been updated in a while
- this means that some nested dependencies - dependencies that these top-level dependencies rely on - became a security risk
![Screenshot 2020-02-21 at 17 52 05](https://user-images.githubusercontent.com/29477363/75059511-05c84680-54d5-11ea-8fff-4aed227e33ae.png)


## Run `npm audit fix`
- added 71 packages from 32 contributors and updated 4 packages
- fixed 7 of 19 vulnerabilities
- 4 package updates for 12 vulnerabilities involved breaking changes and require manual fix
- left with 4 low, 4 moderate, 4 high vulnerabilities

## NPM resolutions?
- updating the top-level dependencies is the way to go
- however, that will most likely involve substantial changes to the code base and more dev time
- a patchy solution is to use resolutions
- npm does not natively support yarn resolutions 
- [`npm-force-resolutions`](https://github.com/rogeriochaves/npm-force-resolutions) adds this functionality
- installed it and added it to package.json scripts as a pre-install feature

## Eliminate high level security threats
- using npm resolutions, we eliminate the high risk vulnerabilities
```
  "js-yaml": "3.13.1",
   "lodash": "4.17.12",
   "tough-cookie": "2.3.3"
```
- 6 vulnerabilities left (3 low, 3 moderate)
## Check dependencies
- add resolutions dealing with the dependencies responsible for those low and moderate risks
![Screenshot 2020-02-21 at 18 20 05](https://user-images.githubusercontent.com/29477363/75060551-f0541c00-54d6-11ea-9782-c803fce3e95e.png)

## Tests don't run
- in this configuration, tests won't run
- solution was to update a test-related dependency to latest version before breaking changes were introduced and to update resolutions
- this brings our vulnerabilities back to 0 and tests are running

## Check tests
- 4/45 tests fail 
- proceeded to update tests that might have been broken by the `testcafe` version upgrade
- result: 2/45 tests fails - not related to the software upgrade