### PR TITLE
1.6/1993 add etag support to market app

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "postcommit": "git update-index --again",
         "prepare": "husky install"
     },
-    "version": "1.6.0-dev",
+    "version": "1.6.0-beta2",
     "lint-staged": {
         "src/**/*.{js,json,yaml,vue}": [
             "eslint --fix --quiet --cache"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "author": "Neontribe Ltd",
     "dependencies": {
         "axios": "^1.3.4",
+        "axios-etag-cache": "^1.4.0",
         "axios-mock-adapter": "^1.21.2",
         "normalize.css": "^8.0.1",
         "route-parser": "0.0.5",

--- a/src/config.js
+++ b/src/config.js
@@ -2,13 +2,13 @@ import pjson from "../package.json";
 
 // --- Defaults ---
 let env = "production",
-    apiBase = "https://voucher-admin.alexandrarose.org.uk/api",
+    apiBase = "https://voucher-admin.neontribe.org/api",
     appVersion = pjson.version;
 
 // --- Env Specific ---
 if (location.hostname.match(/voucher-staging/)) {
     env = "staging";
-    apiBase = "https://voucher-admin-staging.alexandrarose.org.uk/api";
+    apiBase = "https://voucher-admin-staging.neontribe.org/api";
 }
 
 if (location.hostname.match(/localhost|(\.(dev|test))$/)) {

--- a/src/services/netMgr.js
+++ b/src/services/netMgr.js
@@ -11,6 +11,7 @@ const NetMgrFactory = function (config) {
         mockAdapter: null,
         mocker: null,
         online: true,
+        // this will, apparently, attach a magic etag/304 detector
         axiosInstance: axiosETAGCache(Axios.create(config)),
         /**
          * A function that works out if we really are Authenticated.

--- a/src/services/netMgr.js
+++ b/src/services/netMgr.js
@@ -1,6 +1,7 @@
 import Config from "../config.js";
 import Fixtures from "../../fixtures/fixtures.js";
 import Axios from "axios";
+import { axiosETAGCache } from "axios-etag-cache";
 import MockAdapter from "axios-mock-adapter";
 import { EventBus } from "./events";
 
@@ -10,7 +11,7 @@ const NetMgrFactory = function (config) {
         mockAdapter: null,
         mocker: null,
         online: true,
-        axiosInstance: Axios.create(config),
+        axiosInstance: axiosETAGCache(Axios.create(config)),
         /**
          * A function that works out if we really are Authenticated.
          * Rather than what the `Store.auth` actually claims.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2067,6 +2067,11 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+axios-etag-cache@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/axios-etag-cache/-/axios-etag-cache-1.4.0.tgz#8d418370a1d362febfe76d27ffb4fd9c6f9b0c7f"
+  integrity sha512-EsCgszxRvJzUtFA9xIOzlRe5IctfpsIGuvIy7n8rIMyueyhVUOZPpvBnZ0LT9rv2RsBNlE/hL/k3G+SEtBpLew==
+
 axios-mock-adapter@^1.21.2:
   version "1.21.4"
   resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.21.4.tgz#ced09b54b245b338422e3af425ae529bfa26e051"


### PR DESCRIPTION
https://trello.com/c/A13MknJ0/1993-add-etag-support-to-market-app

add the etag library client side; shold now cache etag'd responses for a while and refer to them on a 304