### PR TITLE
css tweaks to allow iPhone 8 to see queued vouchers

### DIFF
--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -406,7 +406,7 @@ footer {
   display: flex;
   font-size: 1em;
   justify-content: space-evenly;
-  padding: 1.2em 2em;
+  padding: 1em 2em;
   position: fixed;
   bottom: 0;
   width: 100%;
@@ -441,6 +441,7 @@ footer {
 .expandable {
   cursor: pointer;
   margin: 1em 0;
+  padding-bottom: 2em;
   font-weight: bold;
   text-decoration: underline;
   &:hover {


### PR DESCRIPTION
https://trello.com/c/AcLijeoK/1999-iphone-unable-to-see-queued-vouchers-obscured-by-footer-on-simulator

This just allows iPhone 8 users to view the queued vouchers as before the list was hidden behind the footer. Here is what it would look like on an iPhone 8 now:
![Screenshot 2023-04-11 at 15 59 11](https://user-images.githubusercontent.com/23450064/231204700-c3ab4a3f-1e76-4a16-9202-8d3b558f1a2c.png)
